### PR TITLE
Add tvOS support

### DIFF
--- a/Classes/MarqueeLabel.swift
+++ b/Classes/MarqueeLabel.swift
@@ -68,7 +68,7 @@ public class MarqueeLabel: UILabel {
 
     /// Start scrolling animation from `home` position
     public func startScrolling() {
-        beginScroll()
+        beginScroll(false)
     }
     
     public var holdScrolling: Bool = false {

--- a/Classes/MarqueeLabel.swift
+++ b/Classes/MarqueeLabel.swift
@@ -63,11 +63,15 @@ public class MarqueeLabel: UILabel {
 
     /// Stop scrolling animation and back to `home` position
     public func stopScrolling() {
+        labelize = true
+        holdScrolling = true
         updateAndScroll(false)
     }
 
     /// Start scrolling animation from `home` position
     public func startScrolling() {
+        labelize = false
+        holdScrolling = false
         beginScroll(false)
     }
     

--- a/Classes/MarqueeLabel.swift
+++ b/Classes/MarqueeLabel.swift
@@ -60,6 +60,16 @@ public class MarqueeLabel: UILabel {
             }
         }
     }
+
+    /// Stop scrolling animation and back to `home` position
+    public func stopScrolling() {
+        updateAndScroll(false)
+    }
+
+    /// Start scrolling animation from `home` position
+    public func startScrolling() {
+        beginScroll()
+    }
     
     public var holdScrolling: Bool = false {
         didSet {

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/AppDelegate.swift
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/AppDelegate.swift
@@ -13,34 +13,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
-
-    func applicationWillResignActive(application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(application: UIApplication) {
-        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-
-
 }
-

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/AppDelegate.swift
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  Demo-tvOS
+//
+//  Created by toshi0383 on 1/9/16.
+//  Copyright © 2016 Charles Powell. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(application: UIApplication) {
+        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
@@ -1,0 +1,26 @@
+{
+  "assets" : [
+    {
+      "size" : "1280x768",
+      "idiom" : "tv",
+      "filename" : "App Icon - Large.imagestack",
+      "role" : "primary-app-icon"
+    },
+    {
+      "size" : "400x240",
+      "idiom" : "tv",
+      "filename" : "App Icon - Small.imagestack",
+      "role" : "primary-app-icon"
+    },
+    {
+      "size" : "1920x720",
+      "idiom" : "tv",
+      "filename" : "Top Shelf Image.imageset",
+      "role" : "top-shelf-image"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/LaunchImage.launchimage/Contents.json
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Assets.xcassets/LaunchImage.launchimage/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "orientation" : "landscape",
+      "idiom" : "tv",
+      "extent" : "full-screen",
+      "minimum-system-version" : "9.0",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Base.lproj/Main.storyboard
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Base.lproj/Main.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="66" sectionHeaderHeight="40" sectionFooterHeight="40" translatesAutoresizingMaskIntoConstraints="NO" id="vFh-7H-vrQ">
-                                <rect key="frame" x="90" y="60" width="420" height="960"/>
+                                <rect key="frame" x="123" y="144" width="420" height="854"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" id="eKO-l2-ZzA" customClass="TableViewCell" customModule="Demo_tvOS" customModuleProvider="target">
@@ -47,9 +47,35 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="66" sectionHeaderHeight="40" sectionFooterHeight="40" translatesAutoresizingMaskIntoConstraints="NO" id="60X-zb-Jho" customClass="DefaultTableView" customModule="Demo_tvOS" customModuleProvider="target">
+                                <rect key="frame" x="699" y="144" width="420" height="854"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <prototypes>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Default" id="Tz7-EY-Vy7">
+                                        <rect key="frame" x="0.0" y="54" width="420" height="66"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Tz7-EY-Vy7" id="pK8-3Y-8RC">
+                                            <rect key="frame" x="0.0" y="0.0" width="404" height="66"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="btN-hn-TSZ" customClass="MarqueeLabel" customModule="MarqueeLabel">
-                                <rect key="frame" x="647" y="143" width="273" height="69"/>
+                                <rect key="frame" x="1227" y="166" width="273" height="69"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="MarqueeLabel" textAlignment="justified" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9SY-Jy-DKX">
+                                <rect key="frame" x="75" y="40" width="433" height="96"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="UITableViewCell" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bt4-3v-lLY">
+                                <rect key="frame" x="661" y="53" width="648" height="69"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -57,6 +83,7 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                     <connections>
+                        <outlet property="defaultTableview" destination="60X-zb-Jho" id="ckx-X0-oYj"/>
                         <outlet property="marquee1" destination="btN-hn-TSZ" id="4i7-SI-Ieu"/>
                         <outlet property="tableview" destination="vFh-7H-vrQ" id="nJd-aF-1lJ"/>
                     </connections>

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Base.lproj/Main.storyboard
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Base.lproj/Main.storyboard
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="Demo_tvOS" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="66" sectionHeaderHeight="40" sectionFooterHeight="40" translatesAutoresizingMaskIntoConstraints="NO" id="vFh-7H-vrQ">
+                                <rect key="frame" x="90" y="60" width="420" height="960"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <prototypes>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" id="eKO-l2-ZzA" customClass="TableViewCell" customModule="Demo_tvOS" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="54" width="420" height="66"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="eKO-l2-ZzA" id="NjZ-hn-HBb">
+                                            <rect key="frame" x="0.0" y="0.0" width="404" height="66"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DBL-yl-WdT" customClass="MarqueeLabel" customModule="MarqueeLabel">
+                                                    <rect key="frame" x="8" y="8" width="404" height="46"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="DBL-yl-WdT" firstAttribute="top" secondItem="NjZ-hn-HBb" secondAttribute="topMargin" id="IGC-l0-hhr"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="DBL-yl-WdT" secondAttribute="trailing" id="ezA-Rd-gSi"/>
+                                                <constraint firstItem="DBL-yl-WdT" firstAttribute="leading" secondItem="NjZ-hn-HBb" secondAttribute="leadingMargin" id="jb6-VK-IG8"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="marquee" destination="DBL-yl-WdT" id="8T3-wm-8b1"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="btN-hn-TSZ" customClass="MarqueeLabel" customModule="MarqueeLabel">
+                                <rect key="frame" x="647" y="143" width="273" height="69"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                    <connections>
+                        <outlet property="marquee1" destination="btN-hn-TSZ" id="4i7-SI-Ieu"/>
+                        <outlet property="tableview" destination="vFh-7H-vrQ" id="nJd-aF-1lJ"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="410" y="327"/>
+        </scene>
+    </scenes>
+</document>

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/Info.plist
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+</dict>
+</plist>

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/ViewController.swift
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/ViewController.swift
@@ -54,8 +54,8 @@ extension ViewController: UITableViewDataSource {
         let cell = tableview.dequeueReusableCellWithIdentifier("Cell") as! CellType!
         cell.marquee.text = labels[indexPath.row]
         cell.marquee.scrollDuration = defaultScrollDuration
-        cell.marquee.holdScrolling = true
         cell.marquee.lineBreakMode = NSLineBreakMode(rawValue: indexPath.row % 6)!
+        cell.marquee.stopScrolling()
         return cell
     }
 }

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/ViewController.swift
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/ViewController.swift
@@ -1,0 +1,73 @@
+//
+//  ViewController.swift
+//  Demo-tvOS
+//
+//  Created by toshi0383 on 1/9/16.
+//  Copyright © 2016 Charles Powell. All rights reserved.
+//
+
+import UIKit
+import MarqueeLabel
+
+class ViewController: UIViewController {
+
+    @IBOutlet var tableview: UITableView!
+    @IBOutlet weak var marquee1: MarqueeLabel!
+
+    var labels = [
+        "Hello Hello Hello World.",
+        "Hello Hello Hello Hello Hello World.",
+        "Hello Hello Hello Hello Hello Hello World.",
+        "Hello Hello Hello Hello Hello Hello Hello World.",
+        "Hello Hello Hello Hello Hello Hello Hello World.",
+        "Hello Hello Hello Hello Hello Hello Hello World.",
+        "Hello Hello Hello Hello Hello Hello Hello World."]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableview.dataSource = self
+        tableview.delegate = self
+
+        marquee1.type = .Continuous
+        marquee1.text = labels.last!
+        marquee1.lineBreakMode = .ByTruncatingHead
+    }
+
+}
+
+typealias CellType = TableViewCell
+
+extension ViewController: UITableViewDataSource {
+
+    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return labels.count
+    }
+
+    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = tableview.dequeueReusableCellWithIdentifier("Cell") as! CellType!
+        cell.marquee.text = labels[indexPath.row]
+        cell.marquee.scrollDuration = 10.0
+        cell.marquee.holdScrolling = true
+        cell.marquee.lineBreakMode = NSLineBreakMode(rawValue: indexPath.row % 6)!
+        return cell
+    }
+}
+
+extension ViewController: UITableViewDelegate {
+    func tableView(tableView: UITableView, didUpdateFocusInContext context: UITableViewFocusUpdateContext, withAnimationCoordinator coordinator: UIFocusAnimationCoordinator) {
+        if let previouslyFocusedIndexPath = context.previouslyFocusedIndexPath {
+            let previous = tableView.cellForRowAtIndexPath(previouslyFocusedIndexPath) as! CellType!
+            previous?.marquee.stopScrolling()
+            print("\(previouslyFocusedIndexPath.row): stopScrolling")
+        }
+        if let nextFocusedIndexPath = context.nextFocusedIndexPath {
+            let next = tableView.cellForRowAtIndexPath(nextFocusedIndexPath) as! CellType!
+            next?.marquee.startScrolling()
+            print("\(nextFocusedIndexPath.row): startScrolling")
+        }
+    }
+}
+
+class TableViewCell: UITableViewCell {
+    @IBOutlet var marquee: MarqueeLabel!
+}

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/ViewController.swift
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/ViewController.swift
@@ -18,6 +18,8 @@ let labels = [
     "Hello Hello Hello Hello Hello Hello Hello World.",
     "Hello Hello Hello Hello Hello Hello Hello World."]
 
+let defaultScrollDuration: CGFloat = 20.0
+
 class ViewController: UIViewController {
 
     @IBOutlet var tableview: UITableView!
@@ -34,6 +36,7 @@ class ViewController: UIViewController {
 
         marquee1.type = .Continuous
         marquee1.text = labels.last!
+        marquee1.scrollDuration = defaultScrollDuration
         marquee1.lineBreakMode = .ByTruncatingHead
     }
 
@@ -50,7 +53,7 @@ extension ViewController: UITableViewDataSource {
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = tableview.dequeueReusableCellWithIdentifier("Cell") as! CellType!
         cell.marquee.text = labels[indexPath.row]
-        cell.marquee.scrollDuration = 10.0
+        cell.marquee.scrollDuration = defaultScrollDuration
         cell.marquee.holdScrolling = true
         cell.marquee.lineBreakMode = NSLineBreakMode(rawValue: indexPath.row % 6)!
         return cell

--- a/MarqueeLabelDemo-Swift/Demo-tvOS/ViewController.swift
+++ b/MarqueeLabelDemo-Swift/Demo-tvOS/ViewController.swift
@@ -9,24 +9,28 @@
 import UIKit
 import MarqueeLabel
 
+let labels = [
+    "Hello Hello Hello World.",
+    "Hello Hello Hello Hello Hello World.",
+    "Hello Hello Hello Hello Hello Hello World.",
+    "Hello Hello Hello Hello Hello Hello Hello World.",
+    "Hello Hello Hello Hello Hello Hello Hello World.",
+    "Hello Hello Hello Hello Hello Hello Hello World.",
+    "Hello Hello Hello Hello Hello Hello Hello World."]
+
 class ViewController: UIViewController {
 
     @IBOutlet var tableview: UITableView!
+    @IBOutlet var defaultTableview: DefaultTableView!
     @IBOutlet weak var marquee1: MarqueeLabel!
 
-    var labels = [
-        "Hello Hello Hello World.",
-        "Hello Hello Hello Hello Hello World.",
-        "Hello Hello Hello Hello Hello Hello World.",
-        "Hello Hello Hello Hello Hello Hello Hello World.",
-        "Hello Hello Hello Hello Hello Hello Hello World.",
-        "Hello Hello Hello Hello Hello Hello Hello World.",
-        "Hello Hello Hello Hello Hello Hello Hello World."]
 
     override func viewDidLoad() {
         super.viewDidLoad()
         tableview.dataSource = self
         tableview.delegate = self
+
+        defaultTableview.dataSource = defaultTableview
 
         marquee1.type = .Continuous
         marquee1.text = labels.last!
@@ -71,3 +75,19 @@ extension ViewController: UITableViewDelegate {
 class TableViewCell: UITableViewCell {
     @IBOutlet var marquee: MarqueeLabel!
 }
+
+class DefaultTableView: UITableView {
+}
+
+extension DefaultTableView: UITableViewDataSource {
+    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return labels.count
+    }
+
+    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = self.dequeueReusableCellWithIdentifier("Default") as UITableViewCell!
+        cell.textLabel?.text = labels[indexPath.row]
+        return cell
+    }
+}
+

--- a/MarqueeLabelDemo-Swift/MarqueeLabel-tvOS/Info.plist
+++ b/MarqueeLabelDemo-Swift/MarqueeLabel-tvOS/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/MarqueeLabelDemo-Swift/MarqueeLabel-tvOS/MarqueeLabel-tvOS.h
+++ b/MarqueeLabelDemo-Swift/MarqueeLabel-tvOS/MarqueeLabel-tvOS.h
@@ -1,0 +1,19 @@
+//
+//  MarqueeLabel-tvOS.h
+//  MarqueeLabel-tvOS
+//
+//  Created by toshi0383 on 1/9/16.
+//  Copyright © 2016 Charles Powell. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for MarqueeLabel-tvOS.
+FOUNDATION_EXPORT double MarqueeLabel_tvOSVersionNumber;
+
+//! Project version string for MarqueeLabel-tvOS.
+FOUNDATION_EXPORT const unsigned char MarqueeLabel_tvOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <MarqueeLabel_tvOS/PublicHeader.h>
+
+

--- a/MarqueeLabelDemo-Swift/MarqueeLabelDemo-Swift.xcodeproj/project.pbxproj
+++ b/MarqueeLabelDemo-Swift/MarqueeLabelDemo-Swift.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F8567AC1C408E63008088FF /* MarqueeLabel-tvOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F8567AB1C408E63008088FF /* MarqueeLabel-tvOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F8567B11C408E8C008088FF /* MarqueeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADD534A1992FDF100E19A42 /* MarqueeLabel.swift */; };
+		1F8567B91C408EB6008088FF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8567B81C408EB6008088FF /* AppDelegate.swift */; };
+		1F8567BB1C408EB6008088FF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8567BA1C408EB6008088FF /* ViewController.swift */; };
+		1F8567BE1C408EB6008088FF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1F8567BC1C408EB6008088FF /* Main.storyboard */; };
+		1F8567C01C408EB6008088FF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1F8567BF1C408EB6008088FF /* Assets.xcassets */; };
+		1F8567C51C409119008088FF /* MarqueeLabel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F8567A91C408E63008088FF /* MarqueeLabel.framework */; };
+		1F8567C61C409119008088FF /* MarqueeLabel.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1F8567A91C408E63008088FF /* MarqueeLabel.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EA08C81C1996DAEE00FB72B6 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA08C81B1996DAEE00FB72B6 /* QuartzCore.framework */; };
 		EA7AF4B01AE5E46F00F31C40 /* MarqueeLabel.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EA7AF4AF1AE5E46F00F31C40 /* MarqueeLabel.storyboard */; };
 		EADD532D1992FD5600E19A42 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADD532C1992FD5600E19A42 /* AppDelegate.swift */; };
@@ -15,7 +23,40 @@
 		EADD534B1992FDF100E19A42 /* MarqueeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EADD534A1992FDF100E19A42 /* MarqueeLabel.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		1F8567C71C409119008088FF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EADD531F1992FD5600E19A42 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1F8567A81C408E63008088FF;
+			remoteInfo = "MarqueeLabel-tvOS";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		1F8567C91C409119008088FF /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				1F8567C61C409119008088FF /* MarqueeLabel.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		1F8567A91C408E63008088FF /* MarqueeLabel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MarqueeLabel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F8567AB1C408E63008088FF /* MarqueeLabel-tvOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MarqueeLabel-tvOS.h"; sourceTree = "<group>"; };
+		1F8567AD1C408E63008088FF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1F8567B61C408EB6008088FF /* Demo-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Demo-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F8567B81C408EB6008088FF /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		1F8567BA1C408EB6008088FF /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		1F8567BD1C408EB6008088FF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		1F8567BF1C408EB6008088FF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		1F8567C11C408EB6008088FF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EA08C81B1996DAEE00FB72B6 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		EA7AF4AF1AE5E46F00F31C40 /* MarqueeLabel.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MarqueeLabel.storyboard; sourceTree = "<group>"; };
 		EADD53271992FD5600E19A42 /* MarqueeLabelDemo-Swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MarqueeLabelDemo-Swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -29,6 +70,21 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1F8567A51C408E63008088FF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F8567B31C408EB6008088FF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F8567C51C409119008088FF /* MarqueeLabel.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EADD53241992FD5600E19A42 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -40,6 +96,27 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1F8567AA1C408E63008088FF /* MarqueeLabel-tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				1F8567AB1C408E63008088FF /* MarqueeLabel-tvOS.h */,
+				1F8567AD1C408E63008088FF /* Info.plist */,
+			);
+			path = "MarqueeLabel-tvOS";
+			sourceTree = "<group>";
+		};
+		1F8567B71C408EB6008088FF /* Demo-tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				1F8567B81C408EB6008088FF /* AppDelegate.swift */,
+				1F8567BA1C408EB6008088FF /* ViewController.swift */,
+				1F8567BC1C408EB6008088FF /* Main.storyboard */,
+				1F8567BF1C408EB6008088FF /* Assets.xcassets */,
+				1F8567C11C408EB6008088FF /* Info.plist */,
+			);
+			path = "Demo-tvOS";
+			sourceTree = "<group>";
+		};
 		EADD531E1992FD5600E19A42 = {
 			isa = PBXGroup;
 			children = (
@@ -47,6 +124,8 @@
 				EADD53491992FDDC00E19A42 /* Classes */,
 				EADD53291992FD5600E19A42 /* MarqueeLabelDemo-Swift */,
 				EADD533C1992FD5600E19A42 /* MarqueeLabelDemo-SwiftTests */,
+				1F8567AA1C408E63008088FF /* MarqueeLabel-tvOS */,
+				1F8567B71C408EB6008088FF /* Demo-tvOS */,
 				EADD53281992FD5600E19A42 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -55,6 +134,8 @@
 			isa = PBXGroup;
 			children = (
 				EADD53271992FD5600E19A42 /* MarqueeLabelDemo-Swift.app */,
+				1F8567A91C408E63008088FF /* MarqueeLabel.framework */,
+				1F8567B61C408EB6008088FF /* Demo-tvOS.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -106,7 +187,55 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		1F8567A61C408E63008088FF /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F8567AC1C408E63008088FF /* MarqueeLabel-tvOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		1F8567A81C408E63008088FF /* MarqueeLabel-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F8567B01C408E63008088FF /* Build configuration list for PBXNativeTarget "MarqueeLabel-tvOS" */;
+			buildPhases = (
+				1F8567A41C408E63008088FF /* Sources */,
+				1F8567A51C408E63008088FF /* Frameworks */,
+				1F8567A61C408E63008088FF /* Headers */,
+				1F8567A71C408E63008088FF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "MarqueeLabel-tvOS";
+			productName = "MarqueeLabel-tvOS";
+			productReference = 1F8567A91C408E63008088FF /* MarqueeLabel.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		1F8567B51C408EB6008088FF /* Demo-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F8567C21C408EB6008088FF /* Build configuration list for PBXNativeTarget "Demo-tvOS" */;
+			buildPhases = (
+				1F8567B21C408EB6008088FF /* Sources */,
+				1F8567B31C408EB6008088FF /* Frameworks */,
+				1F8567B41C408EB6008088FF /* Resources */,
+				1F8567C91C409119008088FF /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1F8567C81C409119008088FF /* PBXTargetDependency */,
+			);
+			name = "Demo-tvOS";
+			productName = "Demo-tvOS";
+			productReference = 1F8567B61C408EB6008088FF /* Demo-tvOS.app */;
+			productType = "com.apple.product-type.application";
+		};
 		EADD53261992FD5600E19A42 /* MarqueeLabelDemo-Swift */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EADD53431992FD5600E19A42 /* Build configuration list for PBXNativeTarget "MarqueeLabelDemo-Swift" */;
@@ -130,10 +259,16 @@
 		EADD531F1992FD5600E19A42 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0720;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Charles Powell";
 				TargetAttributes = {
+					1F8567A81C408E63008088FF = {
+						CreatedOnToolsVersion = 7.2;
+					};
+					1F8567B51C408EB6008088FF = {
+						CreatedOnToolsVersion = 7.2;
+					};
 					EADD53261992FD5600E19A42 = {
 						CreatedOnToolsVersion = 6.0;
 					};
@@ -153,11 +288,29 @@
 			projectRoot = "";
 			targets = (
 				EADD53261992FD5600E19A42 /* MarqueeLabelDemo-Swift */,
+				1F8567A81C408E63008088FF /* MarqueeLabel-tvOS */,
+				1F8567B51C408EB6008088FF /* Demo-tvOS */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1F8567A71C408E63008088FF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F8567B41C408EB6008088FF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F8567C01C408EB6008088FF /* Assets.xcassets in Resources */,
+				1F8567BE1C408EB6008088FF /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EADD53251992FD5600E19A42 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -170,6 +323,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1F8567A41C408E63008088FF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F8567B11C408E8C008088FF /* MarqueeLabel.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F8567B21C408EB6008088FF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F8567BB1C408EB6008088FF /* ViewController.swift in Sources */,
+				1F8567B91C408EB6008088FF /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EADD53231992FD5600E19A42 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -182,7 +352,112 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		1F8567C81C409119008088FF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1F8567A81C408E63008088FF /* MarqueeLabel-tvOS */;
+			targetProxy = 1F8567C71C409119008088FF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		1F8567BC1C408EB6008088FF /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				1F8567BD1C408EB6008088FF /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
+		1F8567AE1C408E63008088FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "MarqueeLabel-tvOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "jp.toshi0383.MarqueeLabel-tvOS";
+				PRODUCT_NAME = MarqueeLabel;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		1F8567AF1C408E63008088FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "MarqueeLabel-tvOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "jp.toshi0383.MarqueeLabel-tvOS";
+				PRODUCT_NAME = MarqueeLabel;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		1F8567C31C408EB6008088FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "Demo-tvOS/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "jp.toshi0383.Demo-tvOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Debug;
+		};
+		1F8567C41C408EB6008088FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = "Demo-tvOS/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "jp.toshi0383.Demo-tvOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Release;
+		};
 		EADD53411992FD5600E19A42 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -286,6 +561,22 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1F8567B01C408E63008088FF /* Build configuration list for PBXNativeTarget "MarqueeLabel-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F8567AE1C408E63008088FF /* Debug */,
+				1F8567AF1C408E63008088FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		1F8567C21C408EB6008088FF /* Build configuration list for PBXNativeTarget "Demo-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F8567C31C408EB6008088FF /* Debug */,
+				1F8567C41C408EB6008088FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		EADD53221992FD5600E19A42 /* Build configuration list for PBXProject "MarqueeLabelDemo-Swift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/MarqueeLabelDemo-Swift/MarqueeLabelDemo-Swift.xcodeproj/xcshareddata/xcschemes/MarqueeLabel-tvOS.xcscheme
+++ b/MarqueeLabelDemo-Swift/MarqueeLabelDemo-Swift.xcodeproj/xcshareddata/xcschemes/MarqueeLabel-tvOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1F8567A81C408E63008088FF"
+               BuildableName = "MarqueeLabel.framework"
+               BlueprintName = "MarqueeLabel-tvOS"
+               ReferencedContainer = "container:MarqueeLabelDemo-Swift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1F8567A81C408E63008088FF"
+            BuildableName = "MarqueeLabel.framework"
+            BlueprintName = "MarqueeLabel-tvOS"
+            ReferencedContainer = "container:MarqueeLabelDemo-Swift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1F8567A81C408E63008088FF"
+            BuildableName = "MarqueeLabel.framework"
+            BlueprintName = "MarqueeLabel-tvOS"
+            ReferencedContainer = "container:MarqueeLabelDemo-Swift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Working on tvOS support in this branch.

Note that tvOS supports scrolling label by default if you use `UITableViewCell.textLabel`.
The default scrolling behavior differs a bit from of MarqueeLabel.
- On **focused** : starts scrolling 
- On **unfocused** : stops scrolling and back to home position without animations .
- Scrolling speed is bit slower than MarqueeLabel. (Maybe `scrollDuration = 20.0` ?)
- lineBreakMode is `ByTruncatingTail` while unfocused

My motivation is to make these behavior available for other tvOS labels in addition to `UITableViewCell.textLabel`.

Please give feedbacks if any.😀
